### PR TITLE
[Rust-Axum] Fix rustfmt error due to ordering

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -230,12 +230,12 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
 
         supportingFiles.add(new SupportingFile("Cargo.mustache", "", "Cargo.toml"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
-        supportingFiles.add(new SupportingFile("lib.mustache", "src", "lib.rs"));
-        supportingFiles.add(new SupportingFile("models.mustache", "src", "models.rs"));
         supportingFiles.add(new SupportingFile("types.mustache", "src", "types.rs"));
         supportingFiles.add(new SupportingFile("header.mustache", "src", "header.rs"));
-        supportingFiles.add(new SupportingFile("server-mod.mustache", "src/server", "mod.rs"));
+        supportingFiles.add(new SupportingFile("models.mustache", "src", "models.rs"));
         supportingFiles.add(new SupportingFile("apis-mod.mustache", apiPackage().replace('.', File.separatorChar), "mod.rs"));
+        supportingFiles.add(new SupportingFile("server-mod.mustache", "src/server", "mod.rs"));
+        supportingFiles.add(new SupportingFile("lib.mustache", "src", "lib.rs"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md").doNotOverwrite());
     }
 


### PR DESCRIPTION
This PR re-orders the list of `supportingFiles` in `/RustAxumServerCodegen.java` so that they are in dependency order. This prevents the following error from `rustfmt` when post-processing is enabled due to `lib.rs` being formatted before referenced modules are created:

```
[main] INFO  o.o.codegen.TemplateManager - writing file /home/tanadeau/openapi/output/server-rust-axum/Cargo.toml
[main] INFO  o.o.codegen.TemplateManager - writing file /home/tanadeau/openapi/output/server-rust-axum/.gitignore
[main] INFO  o.o.codegen.TemplateManager - writing file /home/tanadeau/openapi/output/server-rust-axum/src/lib.rs
[main] ERROR o.o.codegen.DefaultCodegen - Error running the command (rustfmt --edition 2021 /home/tanadeau/openapi/output/server-rust-axum/src/lib.rs). Exit value: 1, Error output: Error writing files: failed to resolve mod `server`: /home/tanadeau/openapi/output/server-rust-axum/src/server.rs does not exist
[main] ERROR o.o.codegen.DefaultCodegen - Error running the command (rustfmt --edition 2021 /home/tanadeau/openapi/output/server-rust-axum/src/lib.rs). Exit value: 1, Error output: Error writing files: failed to resolve mod `server`: /home/tanadeau/openapi/output/server-rust-axum/src/server.rs does not exist
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
